### PR TITLE
Add syntax for tuple element access

### DIFF
--- a/syntax/pony.vim
+++ b/syntax/pony.vim
@@ -22,7 +22,8 @@ syn match   ponyErrNumGroup     /__\+/ contained
 hi def link ponyErrNumGroup     Error
 
 syn match   ponyPeriodComma     /,/ nextgroup=ponyEllipsis,ponyErrOperator skipwhite
-syn match   ponyPeriodComma     /[.;]/ nextgroup=ponyErrOperator skipwhite
+syn match   ponyPeriodComma     /\./ nextgroup=ponyTupleElement,ponyErrOperator skipwhite
+syn match   ponyPeriodComma     /;/ nextgroup=ponyErrOperator skipwhite
 hi def link ponyPeriodComma     Operator
 
 syn match   ponyBracket         /[{[()\]}]/
@@ -65,6 +66,10 @@ syn match   ponyUserMethod      /\v[_a-zA-Z]\w*/ contained contains=ponyErrUserM
 hi def link ponyUserMethod      Function
 syn match   ponyForeignFunction /\v[_a-zA-Z]\w*/ contained nextgroup=ponyGeneric skipwhite
 hi def link ponyForeignFunction Macro
+syn match   ponyErrTupleElement /\v_0+>/ contained
+hi def link ponyErrTupleElement Error
+syn match   ponyTupleElement    /\v_\d+\w@!/ contained contains=ponyErrTupleElement
+hi def link ponyTupleElement    Normal
 
 syn keyword ponyBoolean         true false
 hi def link ponyBoolean         Boolean

--- a/test/pony/test03.pony
+++ b/test/pony/test03.pony
@@ -1,0 +1,45 @@
+primitive TupleElementTest
+  fun errNonIndex() =>
+    let a: I32 = 1
+    let t = (a, a, a)
+    t._1p
+
+  fun errZero() =>
+    let a: I32 = 1
+    let t = (a, a, a)
+    t._0
+    t._00
+
+  fun matchSingleDigit() =>
+    let a: I32 = 1
+    let t = (a, a, a)
+    t._1
+    t._2
+    t._3
+
+  fun matchMultiDigit() =>
+    let a: I32 = 1
+    let t = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a,
+             a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a,
+             a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a,
+             a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+    t._10
+    t._37
+    t._100
+
+  fun matchZeroPadded() =>
+    let a: I32 = 1
+    let t = (a, a, a, a, a, a, a, a, a, a)
+    t._01
+    t._10
+    t._001
+    t._010
+
+  fun noMatchAfterNonPeriod() =>
+    (1, 2, _3)
+    [1; 2; _3]
+
+class NoMatchPrivateField
+  var _x: I32 = 0
+  fun ref swap(other: NoMatchPrivateField) =>
+    _x = (other._x = _x)


### PR DESCRIPTION
This change fixes tuple element access like `tuple._1` being highlighted as error.